### PR TITLE
Add timer command between session end and leaderboard update

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import datetime
 from discord.ext import commands
 from dotenv import load_dotenv
 from typing import Tuple
+import traceback
 
 load_dotenv()
 
@@ -13,7 +14,7 @@ intents.message_content = True
 
 bot = commands.Bot(command_prefix='/', intents=intents, help_command=None)
 
-participants = {}
+all_participants = {}
 progress_submitted = {}
 babble_active = None           
 session_started = None
@@ -23,9 +24,7 @@ start_time = None
 end_time = None
 session_sleep_task = None
 start_sleep_task = None
-
-session_status = "inactive"
-session_status_options = ["inactive", "countdown", "active", "awaiting_progress"]
+submit_end_time = None
 
 DEFAULT_START_IN = 1
 DEFAULT_DURATION = 30
@@ -39,29 +38,30 @@ async def on_ready():
     bot.add_command(drop)
     bot.add_command(progress)
     bot.add_command(help)
-    bot.add_command(participants)
+    bot.add_command(all_participants)
 
     print(f'Logged in as {bot.user.name}')
 
 
 @bot.command()
 async def hi(ctx):
-    await ctx.send('HELLO!')
+    await ctx.send('HELLO !')
 
 
 @bot.command()
 async def babble(ctx, *, params: str = "1 30"):
-    global babble_active, session_started, participants, progress_submitted, start_in, duration, start_time, end_time, start_sleep_task, session_sleep_task
+    global babble_active, session_started, all_participants, progress_submitted, start_in, duration, start_time, end_time, start_sleep_task, session_sleep_task, submit_end_time
     if not babble_active:
         try:
             babble_active = datetime.datetime.now()
             start_in, duration = parse_babble_params(params)
             start_time = datetime.datetime.now() + datetime.timedelta(minutes=start_in)
             end_time = start_time + datetime.timedelta(minutes=duration)
+            submit_end_time = None 
 
             await send_babble_start_message(ctx, start_in, duration)
 
-            participants = {}
+            all_participants = {}
             progress_submitted = {}
             start_sleep_task = asyncio.create_task(asyncio.sleep(start_in * 60))
             await start_sleep_task
@@ -78,18 +78,9 @@ async def babble(ctx, *, params: str = "1 30"):
             start_sleep_task, session_sleep_task = None, None
         except Exception as e:
             await ctx.send(f"An error occurred while executing the babble command: {e}")
+            print(traceback.format_exc())
     else:
         await ctx.send('There is already an active reading challenge.')
-
-
-async def start_session(ctx):
-    global session_sleep_task, session_started
-    session_started = datetime.datetime.now()
-    await send_babble_session_started_message(ctx)
-    session_sleep_task = asyncio.create_task(asyncio.sleep(duration * 60))
-    await session_sleep_task
-    await send_babble_end_message(ctx)
-    session_started = None
 
 
 @bot.command()
@@ -98,10 +89,10 @@ async def join(ctx, *initial_progress):
     Allows a user to join the current reading session. The user can supply an optional parameter 
     to indicate their initial progress in the session.
     """
-    global babble_active, participants, progress_submitted
+    global babble_active, all_participants, progress_submitted
     if babble_active is not None:
-        if ctx.author not in participants:
-            participants[ctx.author] = {'initial': 0, 'current': 0}
+        if ctx.author not in all_participants:
+            all_participants[ctx.author] = {'initial': 0, 'current': 0}
             progress_submitted[ctx.author] = False
             initial_progress = " ".join(initial_progress) 
 
@@ -118,9 +109,9 @@ async def join(ctx, *initial_progress):
 
                 if page.isdigit():
                     page_number = int(page)
-                    participants[ctx.author] = {'initial': page_number, 'current': page_number}
+                    all_participants[ctx.author] = {'initial': page_number, 'current': page_number}
                 else:
-                    del participants[ctx.author]
+                    del all_participants[ctx.author]
                     del progress_submitted[ctx.author]
                     await ctx.send(f'The initial progress provided is not a valid page number. Please try joining again. Use /help for more information.')
                     return
@@ -138,7 +129,7 @@ async def end(ctx):
     """
     Function to end the current session. Will clear the participants list and set babble_active and session_started to None.
     """
-    global babble_active, session_started, start_sleep_task, session_sleep_task, participants, progress_submitted, end_time, start_time
+    global babble_active, session_started, start_sleep_task, session_sleep_task, all_participants, progress_submitted, end_time, start_time
     if babble_active is not None:
         babble_active, session_started = None, None
         end_time, start_time = None, None
@@ -146,7 +137,7 @@ async def end(ctx):
         if session_sleep_task is not None:  
             session_sleep_task.cancel()
         
-        participants.clear()
+        all_participants.clear()
         progress_submitted.clear()
 
         await ctx.send(f"The reading challenge has been ended!")
@@ -160,10 +151,10 @@ async def drop(ctx, mode: str = ''):
     Function for the user to drop out of the current session. 
     User can supply an optional parameter to drop out quietly, which will not send a message to the channel when they drop out.
     """
-    global babble_active, participants, progress_submitted
+    global babble_active, all_participants, progress_submitted
     if babble_active is not None:
-        if ctx.author in participants:
-            del participants[ctx.author]
+        if ctx.author in all_participants:
+            del all_participants[ctx.author]
             del progress_submitted[ctx.author]
             if mode == 'quietly':
                 return
@@ -180,20 +171,33 @@ async def timer(ctx):
     Function to check the time left in the current session. 
     Will print the time left in the session if the session has started. Otherwise, will print the time left until the session starts.
     """
-    global end_time, start_time, babble_active, session_started
-    if babble_active is not None and session_started is None:  
-        time_left = start_time - datetime.datetime.now()
+    global end_time, start_time, babble_active, session_started, submit_end_time
+    now = datetime.datetime.now()
+    
+    if babble_active is not None:
+        if session_started is None:
+            time_left = start_time - now
+            minutes = time_left.seconds // 60
+            seconds = time_left.seconds % 60
+            await ctx.send(f"The session will start in {minutes} minutes and {seconds} seconds.")
+        elif not submit_end_time:
+            time_left = end_time - now
+            minutes = time_left.seconds // 60
+            seconds = time_left.seconds % 60
+            await ctx.send(f"The session will end in {minutes} minutes and {seconds} seconds. Good luck!")
+        else:
+            time_left = submit_end_time - now
+            minutes = time_left.seconds // 60
+            seconds = time_left.seconds % 60
+            await ctx.send(f"Time left to submit your progress: {minutes} minutes and {seconds} seconds.")
+    elif submit_end_time and now <= submit_end_time:
+        time_left = submit_end_time - now
         minutes = time_left.seconds // 60
         seconds = time_left.seconds % 60
-        print(time_left)
-        await ctx.send(f"The session will start in {minutes} minutes and {seconds} seconds.")
-    elif babble_active is not None and session_started is not None:
-        time_left = end_time - datetime.datetime.now()
-        minutes = time_left.seconds // 60
-        seconds = time_left.seconds % 60
-        await ctx.send(f"The session will end in {minutes} minutes and {seconds} seconds. Good luck!")
+        await ctx.send(f"Time left to submit your progress: {minutes} minutes and {seconds} seconds.")
     else:
         await ctx.send("There is no active reading challenge.")
+
 
 
 @bot.command()
@@ -201,9 +205,9 @@ async def participants(ctx):
     """
     Lists all the participants in the reading challenge.
     """
-    global participants
-    if participants:
-        participants_list = "\n".join(member.display_name for member in participants.keys())
+    global all_participants
+    if all_participants:
+        participants_list = "\n".join(member.display_name for member in all_participants.keys())
         await ctx.send(f"Participants:\n{participants_list}")
     else:
         await ctx.send("There are no participants in the reading challenge.")
@@ -211,9 +215,9 @@ async def participants(ctx):
 
 @bot.command()
 async def progress(ctx, *, progress: str):
-    global participants, progress_submitted, session_started
+    global all_participants, progress_submitted, session_started
     if session_started is not None:
-        if ctx.author in participants:
+        if ctx.author in all_participants:
             if progress:
                 if progress.startswith('pg:'):
                     page = progress[3:].lstrip()
@@ -224,15 +228,17 @@ async def progress(ctx, *, progress: str):
 
                 if page.isdigit():
                     page_number = int(page)
-                    participants[ctx.author]['current'] = page_number
+                    all_participants[ctx.author]['current'] = page_number
                     progress_submitted[ctx.author] = True
-                    await ctx.send(f'{ctx.author.mention} has updated their progress to: page {participants[ctx.author]["current"]}')
+                    await ctx.send(f'{ctx.author.mention} has updated their progress to: page {all_participants[ctx.author]["current"]}')
                 else:
                     await ctx.send(f'The progress provided is not a valid page number. Please try updating again.')
             else:
                 await ctx.send('Please provide your progress in the format `/progress pg X` or `/progress X`, where X is the page number.')
         else:
             await ctx.send(f'You\'re not currently participating in the reading challenge. Join us by using the `/join` command!')
+    elif babble_active is not None:
+        await ctx.send("You can't use that command. The reading challenge has not started yet.")
     else:
         await ctx.send('There is no active reading challenge.')
 
@@ -275,21 +281,17 @@ async def send_babble_start_message(ctx, start_in, duration):
 
 
 async def send_babble_end_message(ctx):
-    """
-    Used in babble command. Sends a message indicating the end of the reading challenge
-    and waits for participants to update their progress.
-    """
-    global participants, progress_submitted, session_started
+    global all_participants, progress_submitted, session_started, submit_end_time, start_sleep_task, session_sleep_task, babble_active
 
     if session_started is not None:
         await ctx.send("The reading challenge has ended!")
         await ctx.send("Participants, you have 3 minutes to submit your progress update using the `/progress` command.")
         
-        end_time = datetime.datetime.now() + datetime.timedelta(minutes=3)
-        while datetime.datetime.now() < end_time and not all(progress_submitted.values()):
+        submit_end_time = datetime.datetime.now() + datetime.timedelta(minutes=3)
+        while datetime.datetime.now() < submit_end_time and not all(progress_submitted.values()):
             await asyncio.sleep(3)
         
-        scoreboard = sorted(participants.items(), key=lambda x: x[1]['current'] - x[1]['initial'], reverse=True)
+        scoreboard = sorted(all_participants.items(), key=lambda x: x[1]['current'] - x[1]['initial'], reverse=True)
         
         if scoreboard:
             scoreboard_message = "Scoreboard:\n"
@@ -302,7 +304,10 @@ async def send_babble_end_message(ctx):
             await ctx.send(scoreboard_message)
         else:
             await ctx.send("No participants submitted their progress update.")
-        
+        babble_active, session_started, submit_end_time = None, None, None
+        start_sleep_task, session_sleep_task = None, None
+        all_participants.clear()
+        progress_submitted.clear()
         return
     else:
         await ctx.send("There is no active reading challenge.")
@@ -314,7 +319,7 @@ async def send_babble_session_started_message(ctx):
     Used in babble command. Sends a message indicating the start of the reading session.
     """
     channel = ctx.channel
-    participants_list = [participant.mention for participant in participants.keys()]
+    participants_list = [participant.mention for participant in all_participants.keys()]
     participant_mentions = " ".join(participants_list)
     await channel.send(f"{participant_mentions} The reading challenge has started! Enjoy reading!")
 

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ async def on_ready():
     bot.add_command(drop)
     bot.add_command(progress)
     bot.add_command(help)
-    bot.add_command(all_participants)
+    bot.add_command(participants)
 
     print(f'Logged in as {bot.user.name}')
 


### PR DESCRIPTION
- /timer command now works as expected during progress phase where users can use /progress
- session status correctly updates so no commands can be used after all participants update with /progress OR progress phase ends when 3 minute timer ends (since there is no active or in progress session) 
- rename `global participants` to `all_participants` and fix typo for bot add command to 'participants'